### PR TITLE
Make each unit test procedure tear down singletons.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+# empty to allow importing pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from utils.singleton import destroyAllSingletonInstances
+from utils.singleton import noSingletonsAround
+
+@pytest.fixture(scope="function", autouse=True)
+def my_fixture(): # pylint: disable=invalid-name
+    print('\nINITIALIZATION\n')
+    noSingletonsAround()
+    yield
+    print('\nTEAR DOWN\n')
+    destroyAllSingletonInstances()

--- a/utils/singleton.py
+++ b/utils/singleton.py
@@ -19,4 +19,18 @@ class Singleton(type):
 def destroyAllSingletonInstances():
     global _instances
     _instances = {}
+
+def noSingletonsAround():
+    return len(_instances)==0
     
+class ShortSingltonLivesUnderTest:
+    # https://stackoverflow.com/questions/26405380/how-do-i-correctly-setup-and-teardown-for-my-pytest-class-with-tests
+
+    @classmethod
+    def setup_class(cls): # pylint: disable=invalid-name
+        assert noSingletonsAround()
+
+
+    @classmethod
+    def teardown_class(cls): # pylint: disable=invalid-name
+        destroyAllSingletonInstances()


### PR DESCRIPTION
This pull request tears down singletons at each unit test procedure.

An interesting test command to run to see the teardowns is:

 python .\robot.py test -- -xsvvvv

Let me know what you think?

-Mike
