### PR TITLE
Keep the webserver from crashing on an off-robot robrio development w…

### DIFF
--- a/webserver/webserver.py
+++ b/webserver/webserver.py
@@ -22,8 +22,17 @@ class Webserver(metaclass=Singleton):
         templatingHttpHandler = functools.partial(CasseroleWebServerImpl, 
                                      directory=str(WEB_ROOT))
 
-        hostname=socket.gethostname()   
-        ipAddr=socket.gethostbyname(hostname)   
+        hostname=socket.gethostname()
+        ipAddr="unknown"
+        try:
+            ipAddr=socket.gethostbyname(hostname)
+        except socket.gaierror:
+            # socket.gaierror is thrown when there is no dns server.
+            # This can happen when there is no FRC Radio and the roborio
+            # is connected directly to a dhcp server on a non-robot 
+            # private network during development. Allow this
+            # development mode to work.
+            pass
 
         self.httpServer = ThreadedTCPServer(("", httpPort), templatingHttpHandler)
 


### PR DESCRIPTION
…ithout a DNS server.

On my home setup, I don't have a FRC radio, and I don't have a home DNS server. 

This change allows the roborio to keep running in this configuration.